### PR TITLE
Fix ROM name of the 04-palette example

### DIFF
--- a/04-palette/Makefile
+++ b/04-palette/Makefile
@@ -37,7 +37,7 @@ include config.mk
 # This defines the layout of your game cartridge
 # You can customize it to match your requirements
 # Name of the rom file created
-GAMEROM=03_palette
+GAMEROM=04_palette
 # Game title, long description
 GAMETITLE=Palette test
 include rom.mk


### PR DESCRIPTION
GAMEROM was left at `03_palette`, most likely a copy-paste slip from the previous example, so the 04-palette example builds a cartridge named `03_palette.zip`. Rename it to `04_palette`.